### PR TITLE
 Fix for blank fields being always marked as nullable

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -148,7 +148,6 @@ def get_schema_field(
 
     else:
         _f_name, _f_path, _f_pos, field_options = field.deconstruct()
-        blank = field_options.get("blank", False)
         null = field_options.get("null", False)
         max_length = field_options.get("max_length")
 
@@ -163,7 +162,7 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
-        if field.primary_key or blank or null or optional:
+        if null or optional:
             default = None
             nullable = True
 


### PR DESCRIPTION
#17 

Django-Ninja uses the openapi-schema library to generate OpenAPI schemas for your API endpoints. The problem arises when generating the schema for models with primary keys.

By default, Django's ORM (Object-Relational Mapping) system automatically sets the primary key field of a model as non-nullable. However, when Django-Ninja generates the OpenAPI schema, it incorrectly marks this primary key field as nullable.